### PR TITLE
AB#593: Add support for intermediate CAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ sudo apt -y install az-dcap-client
 ## Usage
 
 ```bash
-era -c config.json -h <IP:PORT> -o root.crt
+era -c config.json -h <IP:PORT> [-output-chain chain.pem] [-output-root root.pem] [-output-intermediate intermediate.pem]
 ```
 
 For testing without quote verification use:
 
 ```bash
-era -skip-quote -c config.json -h <IP:PORT> -o root.crt
+era -skip-quote -c config.json -h <IP:PORT> [-output-chain chain.pem] [-output-root root.pem] [-output-intermediate intermediate.pem]
 ```

--- a/cmd/era/main.go
+++ b/cmd/era/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/pem"
 	"errors"
 	"flag"
 	"fmt"
@@ -29,7 +30,7 @@ func main() {
 		return
 	}
 
-	var certs []string
+	var certs []*pem.Block
 	var err error
 	if *skipQuote {
 		fmt.Println("WARNING: Skipping quote verification")
@@ -52,7 +53,7 @@ func main() {
 
 	// Write root certificate as PEM to disk
 	if *outputRoot != "" {
-		if err := ioutil.WriteFile(*outputRoot, []byte(certs[len(certs)-1]), 0644); err != nil {
+		if err := ioutil.WriteFile(*outputRoot, pem.EncodeToMemory(certs[len(certs)-1]), 0644); err != nil {
 			panic(err)
 		}
 		fmt.Println("Root certificate writen to", *outputRoot)
@@ -61,7 +62,7 @@ func main() {
 	// Write intermediate certificate as PEM to disk
 	if *outputIntermediate != "" {
 		if len(certs) > 1 {
-			if err := ioutil.WriteFile(*outputIntermediate, []byte(certs[0]), 0644); err != nil {
+			if err := ioutil.WriteFile(*outputIntermediate, pem.EncodeToMemory(certs[0]), 0644); err != nil {
 				panic(err)
 			}
 			fmt.Println("Intermediate certificate writen to", *outputIntermediate)
@@ -73,12 +74,12 @@ func main() {
 	// Write certificate chain as PEM to disk
 	if *outputChain != "" {
 		if len(certs) > 1 {
-			var chain string
+			var chain []byte
 			for _, cert := range certs {
-				chain += cert
+				chain = append(chain, pem.EncodeToMemory(cert)...)
 			}
 
-			if err := ioutil.WriteFile(*outputChain, []byte(chain), 0644); err != nil {
+			if err := ioutil.WriteFile(*outputChain, chain, 0644); err != nil {
 				panic(err)
 			}
 

--- a/cmd/era/main.go
+++ b/cmd/era/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -11,21 +12,30 @@ import (
 func main() {
 	host := flag.String("h", "", "host address, required")
 	configFilename := flag.String("c", "", "config file, required")
-	out := flag.String("o", "", "output file, required")
+	outputRoot := flag.String("output-root", "", "output file for root certificate")
+	outputIntermediate := flag.String("output-intermediate", "", "output file for intermediate certificate")
+	outputChain := flag.String("output-chain", "", "output file for certificate chain")
 	skipQuote := flag.Bool("skip-quote", false, "skip quote verification")
 	flag.Parse()
-	if *host == "" || *configFilename == "" || *out == "" {
+
+	var noOutputGiven bool
+	if *outputRoot == "" && *outputIntermediate == "" && *outputChain == "" {
+		noOutputGiven = true
+		fmt.Println("ERROR: You need to provide at least one type of output. Check usage for more information.")
+	}
+
+	if *host == "" || *configFilename == "" || noOutputGiven {
 		flag.Usage()
 		return
 	}
 
-	var cert string
+	var certs []string
 	var err error
 	if *skipQuote {
-		fmt.Println("Warning: skipping quote verification")
-		cert, err = era.InsecureGetCertificate(*host)
+		fmt.Println("WARNING: Skipping quote verification")
+		certs, err = era.InsecureGetCertificate(*host)
 	} else {
-		cert, err = era.GetCertificate(*host, *configFilename)
+		certs, err = era.GetCertificate(*host, *configFilename)
 	}
 
 	if err != nil {
@@ -36,8 +46,46 @@ func main() {
 		panic(err)
 	}
 
-	if err := ioutil.WriteFile(*out, []byte(cert), 0644); err != nil {
-		panic(err)
+	if len(certs) == 0 {
+		panic(errors.New("no certificate retrieved from host"))
 	}
-	fmt.Println("SUCCESS, certificate writen to", *out)
+
+	// Write root certificate as PEM to disk
+	if *outputRoot != "" {
+		if err := ioutil.WriteFile(*outputRoot, []byte(certs[len(certs)-1]), 0644); err != nil {
+			panic(err)
+		}
+		fmt.Println("Root certificate writen to", *outputRoot)
+	}
+
+	// Write intermediate certificate as PEM to disk
+	if *outputIntermediate != "" {
+		if len(certs) > 1 {
+			if err := ioutil.WriteFile(*outputIntermediate, []byte(certs[0]), 0644); err != nil {
+				panic(err)
+			}
+			fmt.Println("Intermediate certificate writen to", *outputIntermediate)
+		} else {
+			fmt.Println("WARNING: No intermediate certificate received.")
+		}
+	}
+
+	// Write certificate chain as PEM to disk
+	if *outputChain != "" {
+		if len(certs) > 1 {
+			var chain string
+			for _, cert := range certs {
+				chain += cert
+			}
+
+			if err := ioutil.WriteFile(*outputChain, []byte(chain), 0644); err != nil {
+				panic(err)
+			}
+
+			fmt.Println("Certificate chain writen to", *outputChain)
+		} else {
+			fmt.Println("WARNING: Only received root certificate from host.")
+			fmt.Println("No chain will be saved on disk. Use '-output-root' for products using only a root CA as trust anchor")
+		}
+	}
 }

--- a/era/era.go
+++ b/era/era.go
@@ -28,44 +28,55 @@ var ErrEmptyQuote = errors.New("no quote received")
 
 // GetCertificate gets the TLS certificate from the server in PEM format. It performs remote attestation
 // to verify the certificate. A config file must be provided that contains the attestation metadata.
-func GetCertificate(host, configFilename string) (string, error) {
+func GetCertificate(host, configFilename string) ([]string, error) {
 	config, err := ioutil.ReadFile(configFilename)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	return getCertificate(host, config, erthost.VerifyRemoteReport)
 }
 
 // InsecureGetCertificate gets the TLS certificate from the server in PEM format, but does not perform remote attestation.
-func InsecureGetCertificate(host string) (string, error) {
+func InsecureGetCertificate(host string) ([]string, error) {
 	return getCertificate(host, nil, nil)
 }
 
-func getCertificate(host string, config []byte, verifyRemoteReport func([]byte) (ert.Report, error)) (string, error) {
+func getCertificate(host string, config []byte, verifyRemoteReport func([]byte) (ert.Report, error)) ([]string, error) {
 	cert, quote, err := httpGetCertQuote(&tls.Config{InsecureSkipVerify: true}, host, "quote")
 	if err != nil {
-		return "", err
+		return nil, err
+	}
+
+	certs := make([]string, 0)
+	block, rest := pem.Decode([]byte(cert))
+	certs = append(certs, string(pem.EncodeToMemory(block)))
+
+	// If we get more than one certificate, append it to the slice
+	for len(rest) > 0 {
+		block, rest = pem.Decode([]byte(rest))
+		certs = append(certs, string(pem.EncodeToMemory(block)))
 	}
 
 	if verifyRemoteReport != nil {
 		if len(quote) == 0 {
-			return "", ErrEmptyQuote
+			return nil, ErrEmptyQuote
 		}
 
 		report, err := verifyRemoteReport(quote)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 
-		block, _ := pem.Decode([]byte(cert))
+		// Use Root CA (last entry in certs) for attestation
+		block, _ := pem.Decode([]byte(certs[len(certs)-1]))
 		certRaw := block.Bytes
 
 		if err := verifyReport(report, certRaw, config); err != nil {
-			return "", err
+			return nil, err
 		}
 	}
 
-	return cert, nil
+	return certs, nil
 }
 
 func verifyReport(report ert.Report, cert []byte, config []byte) error {

--- a/era/era.go
+++ b/era/era.go
@@ -49,11 +49,17 @@ func getCertificate(host string, config []byte, verifyRemoteReport func([]byte) 
 
 	var certs []*pem.Block
 	block, rest := pem.Decode([]byte(cert))
+	if block == nil {
+		return nil, errors.New("could not parse certificate")
+	}
 	certs = append(certs, block)
 
 	// If we get more than one certificate, append it to the slice
 	for len(rest) > 0 {
 		block, rest = pem.Decode([]byte(rest))
+		if block == nil {
+			return nil, errors.New("could not parse certificate chain")
+		}
 		certs = append(certs, block)
 	}
 

--- a/era/era_test.go
+++ b/era/era_test.go
@@ -43,12 +43,12 @@ func TestGetCertificate(t *testing.T) {
 	defer server.Close()
 
 	// get certificate without quote validation
-	actualCert, err := getCertificate(addr, nil, nil)
+	actualCerts, err := getCertificate(addr, nil, nil)
 	assert.Nil(err)
-	assert.Equal(expectedCert, actualCert)
+	assert.Equal(expectedCert, actualCerts[0])
 
 	// get certificate with quote validation
-	actualCert, err = getCertificate(addr, config,
+	actualCerts, err = getCertificate(addr, config,
 		func(reportBytes []byte) (ert.Report, error) {
 			assert.Equal(quote, reportBytes)
 			return ert.Report{
@@ -59,10 +59,10 @@ func TestGetCertificate(t *testing.T) {
 			}, nil
 		})
 	assert.Nil(err)
-	assert.Equal(expectedCert, actualCert)
+	assert.Equal(expectedCert, actualCerts[0])
 
 	// verify fails
-	actualCert, err = getCertificate(addr, config,
+	actualCerts, err = getCertificate(addr, config,
 		func(reportBytes []byte) (ert.Report, error) {
 			assert.Equal(quote, reportBytes)
 			return ert.Report{}, errors.New("")
@@ -70,11 +70,11 @@ func TestGetCertificate(t *testing.T) {
 	assert.NotNil(err)
 
 	// invalid addr
-	actualCert, err = getCertificate("", nil, nil)
+	actualCerts, err = getCertificate("", nil, nil)
 	assert.NotNil(err)
 
 	// invalid hash
-	actualCert, err = getCertificate(addr, config,
+	actualCerts, err = getCertificate(addr, config,
 		func(reportBytes []byte) (ert.Report, error) {
 			assert.Equal(quote, reportBytes)
 			hashCopy := hash
@@ -90,7 +90,7 @@ func TestGetCertificate(t *testing.T) {
 	assert.NotNil(err)
 
 	// invalid security version
-	actualCert, err = getCertificate(addr, config,
+	actualCerts, err = getCertificate(addr, config,
 		func(reportBytes []byte) (ert.Report, error) {
 			assert.Equal(quote, reportBytes)
 			return ert.Report{
@@ -103,7 +103,7 @@ func TestGetCertificate(t *testing.T) {
 	assert.NotNil(err)
 
 	// newer security version
-	actualCert, err = getCertificate(addr, config,
+	actualCerts, err = getCertificate(addr, config,
 		func(reportBytes []byte) (ert.Report, error) {
 			assert.Equal(quote, reportBytes)
 			return ert.Report{
@@ -114,10 +114,10 @@ func TestGetCertificate(t *testing.T) {
 			}, nil
 		})
 	assert.Nil(err)
-	assert.Equal(expectedCert, actualCert)
+	assert.Equal(expectedCert, actualCerts[0])
 
 	// invalid product
-	actualCert, err = getCertificate(addr, config,
+	actualCerts, err = getCertificate(addr, config,
 		func(reportBytes []byte) (ert.Report, error) {
 			assert.Equal(quote, reportBytes)
 			return ert.Report{
@@ -130,7 +130,7 @@ func TestGetCertificate(t *testing.T) {
 	assert.NotNil(err)
 
 	// invalid signer
-	actualCert, err = getCertificate(addr, config,
+	actualCerts, err = getCertificate(addr, config,
 		func(reportBytes []byte) (ert.Report, error) {
 			assert.Equal(quote, reportBytes)
 			return ert.Report{

--- a/era/era_test.go
+++ b/era/era_test.go
@@ -45,7 +45,7 @@ func TestGetCertificate(t *testing.T) {
 	// get certificate without quote validation
 	actualCerts, err := getCertificate(addr, nil, nil)
 	assert.Nil(err)
-	assert.Equal(expectedCert, actualCerts[0])
+	assert.EqualValues(expectedCert, pem.EncodeToMemory(actualCerts[0]))
 
 	// get certificate with quote validation
 	actualCerts, err = getCertificate(addr, config,
@@ -59,7 +59,7 @@ func TestGetCertificate(t *testing.T) {
 			}, nil
 		})
 	assert.Nil(err)
-	assert.Equal(expectedCert, actualCerts[0])
+	assert.EqualValues(expectedCert, pem.EncodeToMemory(actualCerts[0]))
 
 	// verify fails
 	actualCerts, err = getCertificate(addr, config,
@@ -114,7 +114,7 @@ func TestGetCertificate(t *testing.T) {
 			}, nil
 		})
 	assert.Nil(err)
-	assert.Equal(expectedCert, actualCerts[0])
+	assert.EqualValues(expectedCert, pem.EncodeToMemory(actualCerts[0]))
 
 	// invalid product
 	actualCerts, err = getCertificate(addr, config,

--- a/era/era_test.go
+++ b/era/era_test.go
@@ -1,13 +1,18 @@
 package era
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/sha256"
+	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/edgelesssys/ertgolib/ert"
 	"github.com/stretchr/testify/assert"
@@ -143,9 +148,84 @@ func TestGetCertificate(t *testing.T) {
 	assert.NotNil(err)
 }
 
+func TestGetMultipleCertificates(t *testing.T) {
+	config := []byte(`
+	{
+		"securityVersion": 2,
+		"productID": 3,
+		"signerID": "ABCD"
+	}
+	`)
+
+	assert := assert.New(t)
+	var quote []byte
+	var certs string
+
+	server, addr, expectedCerts := newServerMultipleCertificates(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("/quote", r.RequestURI)
+		jsn, err := json.Marshal(certQuoteResp{certs, quote})
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+		w.Write(jsn)
+	}))
+	certs = expectedCerts[0] + expectedCerts[1]
+	block, _ := pem.Decode([]byte(expectedCerts[1])) // last one is supposed to be root CA, which we use for quoting
+	certRaw := block.Bytes
+	hash := sha256.Sum256([]byte(certRaw))
+	quote = hash[:]
+
+	defer server.Close()
+
+	// get certificates without quote validation
+	actualCerts, err := getCertificate(addr, nil, nil)
+	assert.Nil(err)
+	assert.EqualValues(expectedCerts[0], pem.EncodeToMemory(actualCerts[0]))
+	assert.EqualValues(expectedCerts[1], pem.EncodeToMemory(actualCerts[1]))
+
+	// get certificates with quote validation
+	actualCerts, err = getCertificate(addr, config,
+		func(reportBytes []byte) (ert.Report, error) {
+			assert.Equal(quote, reportBytes)
+			return ert.Report{
+				Data:            hash[:],
+				SecurityVersion: 2,
+				ProductID:       []byte{0x03, 0x00},
+				SignerID:        []byte{0xAB, 0xCD},
+			}, nil
+		})
+	assert.Nil(err)
+	assert.EqualValues(expectedCerts[0], pem.EncodeToMemory(actualCerts[0]))
+	assert.EqualValues(expectedCerts[1], pem.EncodeToMemory(actualCerts[1]))
+}
+
 func newServer(handler http.Handler) (server *httptest.Server, addr string, cert string) {
 	s := httptest.NewTLSServer(handler)
 	return s, s.Listener.Addr().String(), toPEM(s.Certificate().Raw)
+}
+
+func newServerMultipleCertificates(handler http.Handler) (server *httptest.Server, addr string, certs []string) {
+	// Create a second test certificate
+	key, err := rsa.GenerateKey(rand.Reader, 3096)
+	if err != nil {
+		panic(err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(42),
+		IsCA:         false,
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour * 24 * 365),
+	}
+
+	testCertRaw, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		panic(err)
+	}
+
+	s := httptest.NewTLSServer(handler)
+	expectedCerts := []string{toPEM(testCertRaw), toPEM(s.Certificate().Raw)}
+	return s, s.Listener.Addr().String(), expectedCerts
 }
 
 func toPEM(certificate []byte) string {


### PR DESCRIPTION
Changes:

- Support for outputting root CA, intermediate CA or whole certificate chain
- Use pem.Blocks internally, not strings, and just convert to a string when we want to output stuff to the user
- Added appropriate unit test based on the first one

The parameter -o has been superseded by the following three parameters:
- `-output-root` (saves the last certificate in chain, always works)
- `-output-intermediate` (saves the first certificate in chain, only works with 2+ certificates)
- `-output-chain` (saves the whole chain returned by quote, only works with 2+ certificates)

Note: PEM certificate chains work in reversed order, meaning the first entry in a PEM is a leaf certificate, and its issuer(s) are the succeeding entries.