### PR TITLE
Feat/debug

### DIFF
--- a/era/era.go
+++ b/era/era.go
@@ -96,6 +96,7 @@ func verifyReport(report ert.Report, cert []byte, config []byte) error {
 		UniqueID        string
 		SignerID        string
 		ProductID       uint16
+		Debug           bool
 	}
 	if err := json.Unmarshal(config, &cfg); err != nil {
 		return err
@@ -114,6 +115,9 @@ func verifyReport(report ert.Report, cert []byte, config []byte) error {
 	}
 	if cfg.ProductID != 0 && binary.LittleEndian.Uint16(report.ProductID) != cfg.ProductID {
 		return errors.New("invalid product")
+	}
+	if report.Debug && !cfg.Debug {
+		return errors.New("debug enclave not allowed")
 	}
 	if err := verifyID(cfg.UniqueID, report.UniqueID, "unqiueID"); err != nil {
 		return err

--- a/era/era.go
+++ b/era/era.go
@@ -100,17 +100,19 @@ func verifyReport(report ert.Report, cert []byte, config []byte) error {
 	if err := json.Unmarshal(config, &cfg); err != nil {
 		return err
 	}
-	if cfg.SecurityVersion == 0 {
-		return errors.New("missing securityVersion in config")
-	}
-	if cfg.ProductID == 0 {
-		return errors.New("missing productID in config")
+	if cfg.UniqueID == "" {
+		if cfg.SecurityVersion == 0 {
+			return errors.New("missing securityVersion in config")
+		}
+		if cfg.ProductID == 0 {
+			return errors.New("missing productID in config")
+		}
 	}
 
-	if report.SecurityVersion < cfg.SecurityVersion {
+	if cfg.SecurityVersion != 0 && report.SecurityVersion < cfg.SecurityVersion {
 		return errors.New("invalid security version")
 	}
-	if binary.LittleEndian.Uint16(report.ProductID) != cfg.ProductID {
+	if cfg.ProductID != 0 && binary.LittleEndian.Uint16(report.ProductID) != cfg.ProductID {
 		return errors.New("invalid product")
 	}
 	if err := verifyID(cfg.UniqueID, report.UniqueID, "unqiueID"); err != nil {

--- a/era/era_test.go
+++ b/era/era_test.go
@@ -217,6 +217,36 @@ func TestGetCertificate(t *testing.T) {
 			}, nil
 		})
 	assert.Error(err)
+
+	// debug enclave not allowed
+	_, err = getCertificate(addr, config,
+		func(reportBytes []byte) (ert.Report, error) {
+			assert.Equal(quote, reportBytes)
+			return ert.Report{
+				Data:     hash[:],
+				UniqueID: []byte{0xAB, 0xCD},
+				Debug:    true,
+			}, nil
+		})
+	assert.Error(err)
+
+	// debug enclave allowed
+	config = []byte(`
+{
+	"uniqueID": "ABCD",
+	"debug": true
+}
+`)
+	_, err = getCertificate(addr, config,
+		func(reportBytes []byte) (ert.Report, error) {
+			assert.Equal(quote, reportBytes)
+			return ert.Report{
+				Data:     hash[:],
+				UniqueID: []byte{0xAB, 0xCD},
+				Debug:    true,
+			}, nil
+		})
+	assert.NoError(err)
 }
 
 func TestGetCertificateNewFormat(t *testing.T) {


### PR DESCRIPTION
era should reject debug enclaves by default.
This is a breaking change. We must update all of our era jsons to include `"Debug": true`