### PR TITLE
update DCAP version of PCCS

### DIFF
--- a/pccs/Dockerfile
+++ b/pccs/Dockerfile
@@ -29,7 +29,7 @@
 FROM ubuntu:20.04 AS builder
 
 # DCAP version (github repo branch, tag or commit hash)
-ARG DCAP_VERSION=DCAP_1.14
+ARG DCAP_VERSION=DCAP_1.16
 
 # update and install packages
 RUN DEBIAN_FRONTEND=noninteractive \

--- a/pccs/setup.sh
+++ b/pccs/setup.sh
@@ -40,4 +40,4 @@ sed -i "s/\"AdminTokenHash\"[ ]*:[ ]*\"\",/\"AdminTokenHash\": \"$adminhash\",/"
 sed -i 's/\"hosts\"[ ]*:[ ]*\"127.0.0.1\",/\"hosts\": \"0.0.0.0\",/' default.json
 
 cd ..
-/usr/bin/node -r esm /opt/intel/pccs/pccs_server.js
+/usr/bin/node /opt/intel/pccs/pccs_server.js


### PR DESCRIPTION
New ERT version will support PCS API v4. The PCCS needs a newer DCAP version to also support it.